### PR TITLE
Fix build on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,5 +50,10 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
         ${LIBGIT2_LIBRARIES}
 )
 
+# Link required directories
+target_link_directories(${PROJECT_NAME} PRIVATE
+        ${LIBGIT2_LIBRARY_DIRS}
+)
+
 # Installation setup
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)

--- a/modules/git_statistics.cpp
+++ b/modules/git_statistics.cpp
@@ -65,7 +65,7 @@ int GitModule::commit_callback(const git_commit* commit, void* payload) {
 
     git_time_t time = git_commit_time(commit);           // Get commit timestamp
     char time_str[20];                                   // Buffer for formatted time
-    strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", localtime(&time));  // Format timestamp
+    strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", localtime((const long *)&time));  // Format timestamp
     std::string commit_date(time_str);                   // Convert to string
 
     // Update first and last commit dates

--- a/src/output_formatter.cpp
+++ b/src/output_formatter.cpp
@@ -1,3 +1,4 @@
+#include <sstream>
 #include <iostream>
 #include "output_formatter.hpp"
 


### PR DESCRIPTION
Hi!
Thank you for great tool!

This PR fixes following errors during building on macOS:
```
-- The C compiler identification is AppleClang 17.0.0.17000013
-- The CXX compiler identification is AppleClang 17.0.0.17000013
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Found PkgConfig: /opt/homebrew/bin/pkg-config (found version "2.4.3")
-- Checking for module 'libgit2'
--   Found libgit2, version 1.9.0
-- Configuring done (0.7s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/iliani/projects/personal/codefetch/build
[2/13] Building CXX object CMakeFiles/codefetch.dir/src/output_formatter.cpp.o
FAILED: CMakeFiles/codefetch.dir/src/output_formatter.cpp.o
/usr/bin/c++ -DPROJECT_VERSION=\"0.10.2\" -I/Users/iliani/projects/personal/codefetch -I/Users/iliani/projects/personal/codefetch/src -I/Users/iliani/projects/personal/codefetch/modules -I/opt/homebrew/Cellar/libgit2/1.9.0/include -std=gnu++20 -arch arm64 -MD -MT CMakeFiles/codefetch.dir/src/output_formatter.cpp.o -MF CMakeFiles/codefetch.dir/src/output_formatter.cpp.o.d -o CMakeFiles/codefetch.dir/src/output_formatter.cpp.o -c /Users/iliani/projects/personal/codefetch/src/output_formatter.cpp
/Users/iliani/projects/personal/codefetch/src/output_formatter.cpp:41:24: error: implicit instantiation of undefined template 'std::basic_ostringstream<char>'
   41 |     std::ostringstream oss;                                         // String stream for number formatting
      |                        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__fwd/sstream.h:28:28: note: template is declared here
   28 | class _LIBCPP_TEMPLATE_VIS basic_ostringstream;
      |                            ^
/Users/iliani/projects/personal/codefetch/src/output_formatter.cpp:47:24: error: implicit instantiation of undefined template 'std::basic_ostringstream<char>'
   47 |     std::ostringstream oss;                                        // String stream for number formatting
      |                        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__fwd/sstream.h:28:28: note: template is declared here
   28 | class _LIBCPP_TEMPLATE_VIS basic_ostringstream;
      |                            ^
2 errors generated.
[11/13] Building CXX object CMakeFiles/codefetch.dir/modules/git_statistics.cpp.o
FAILED: CMakeFiles/codefetch.dir/modules/git_statistics.cpp.o
/usr/bin/c++ -DPROJECT_VERSION=\"0.10.2\" -I/Users/iliani/projects/personal/codefetch -I/Users/iliani/projects/personal/codefetch/src -I/Users/iliani/projects/personal/codefetch/modules -I/opt/homebrew/Cellar/libgit2/1.9.0/include -std=gnu++20 -arch arm64 -MD -MT CMakeFiles/codefetch.dir/modules/git_statistics.cpp.o -MF CMakeFiles/codefetch.dir/modules/git_statistics.cpp.o.d -o CMakeFiles/codefetch.dir/modules/git_statistics.cpp.o -c /Users/iliani/projects/personal/codefetch/modules/git_statistics.cpp
/Users/iliani/projects/personal/codefetch/modules/git_statistics.cpp:68:63: error: no matching function for call to 'localtime'
   68 |     strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", localtime(&time));  // Format timestamp
      |                                                               ^~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_time.h:117:12: note: candidate function not viable: no known conversion from 'git_time_t *' (aka 'long long *') to 'const time_t *' (aka 'const long *') for 1st argument
  117 | struct tm *localtime(const time_t *);
      |            ^         ~~~~~~~~~~~~~~
1 error generated.
ninja: build stopped: subcommand failed.
```
And during linking:
```
[1/1] Linking CXX executable codefetch
FAILED: codefetch
: && /usr/bin/c++ -arch arm64 -Wl,-search_paths_first -Wl,-headerpad_max_install_names  CMakeFiles/codefetch.dir/src/main.cpp.o CMakeFiles/codefetch.dir/src/file_utils.cpp.o CMakeFiles/codefetch.dir/src/line_count_util.cpp.o CMakeFiles/codefetch.dir/src/thread_safe_queue.cpp.o CMakeFiles/codefetch.dir/src/output_formatter.cpp.o CMakeFiles/codefetch.dir/modules/total_lines.cpp.o CMakeFiles/codefetch.dir/modules/language_stats_lib.cpp.o CMakeFiles/codefetch.dir/modules/language_stats.cpp.o CMakeFiles/codefetch.dir/modules/metabuild_system.cpp.o CMakeFiles/codefetch.dir/modules/license_detect.cpp.o CMakeFiles/codefetch.dir/modules/git_statistics.cpp.o CMakeFiles/codefetch.dir/modules/file_extension_to_language_map.cpp.o -o codefetch  -lgit2 && :
ld: library 'git2' not found
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```